### PR TITLE
feat: Implement lexer position checkpoints

### DIFF
--- a/src/lexer/lexer_error.rs
+++ b/src/lexer/lexer_error.rs
@@ -19,12 +19,15 @@ pub struct LexerError {
     pub position:     Position,
     /// Current stack of states in the [Lexer](crate::lexer::Lexer).
     pub states_stack: Vec<String>,
+    /// Current marked positions in the [Lexer](crate::lexer::Lexer).
+    pub marks: Vec<Position>,
 }
 
 impl std::fmt::Display for LexerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Error: {}", &self.message)?;
         writeln!(f, "At: {}", self.position)?;
-        write!(f, "With states stack: {:?}", self.states_stack)
+        writeln!(f, "With states stack: {:?}", self.states_stack)?;
+        write!(f, "With marks: {:?}", self.marks)
     }
 }

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -39,6 +39,7 @@ pub struct Lexer<'a> {
     current_rule_name:     &'a str,
     position:              Position,
     states_stack:          LinkedList<&'a str>,
+    marks:                 LinkedList<Position>,
 }
 
 /// Return type of a lexer rule action.
@@ -100,6 +101,11 @@ impl<'a> Lexer<'a> {
                         .states_stack
                         .iter()
                         .map(|state| state.to_string())
+                        .collect(),
+                    marks: self
+                        .marks
+                        .iter()
+                        .map(|mark| mark.clone())
                         .collect(),
                 });
             }
@@ -223,7 +229,22 @@ impl<'a> Lexer<'a> {
                 .iter()
                 .map(|state| state.to_string())
                 .collect(),
+            marks: self
+                .marks
+                .iter()
+                .map(|mark| mark.clone())
+                .collect(),
         })
+    }
+
+    /// Adds a new position to the [Lexer]'s marks stack.
+    pub fn push_mark(&mut self) {
+        self.marks.push_back(self.position.clone());
+    }
+
+    /// Removes the last position from the [Lexer]'s marks stack.
+    pub fn pop_mark(&mut self) {
+        self.marks.pop_back();
     }
 }
 
@@ -239,6 +260,7 @@ pub fn lex(
         current_rule_name: "",
         position: Position { column: 1, line: 1 },
         states_stack: LinkedList::new(),
+        marks: LinkedList::new(),
     };
 
     lexer.push_state("DEFAULT");


### PR DESCRIPTION
This provides two new methods:
- `push_mark` adds current lexer position to the lexer's `marks` stack
- `pop_mark` pops the last position from the stack

This is quite useful to use previously visited positions in the error reporting.
For example, I use this to point to the start of an unterminated multiline comment while the original error would only provide the position of the end-of-file.